### PR TITLE
Handle unused control arguments(index, bool) in replace

### DIFF
--- a/SYS_ATL/LoopIR_unification.py
+++ b/SYS_ATL/LoopIR_unification.py
@@ -701,10 +701,13 @@ class Unification:
                                      stmt_block[0].srcinfo)
             elif fa.type == T.bool:
                 if fa.name in self.bool_holes:
-                    return self.bool_holes[fa.name]
+                    if self.bool_holes[fa.name] is False:
+                        return LoopIR.Const(False, T.bool, stmt_block[0].srcinfo)
+                    else:
+                        return self.bool_holes[fa.name]
                 else:
-                    # doesn't matter; argument un-used
-                    return LoopIR.Const(True, T.bool, stmt_block[0].srcinfo)
+                    # subprocedure argument must be consistent
+                    assert False, "bad case"
             elif fa.type == T.stride:
                 if fa.name in self.stride_holes:
                     return self.stride_holes[fa.name]

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -340,3 +340,24 @@ def test_unify6():
 
     bar = bar.replace(load, "for i in _:_")
     assert 'load(16, 16, A[0:16, 16 * k + 0:16 * k + 16], a[0:16, 0:16])' in str(bar)
+
+# Unused arguments
+def test_unify7():
+    @proc
+    def bar(unused_b : bool, n : size, src : R[n,n], dst : R[n,n], unused_m : index):
+        for i in par(0,n):
+            for j in par(0,n):
+                dst[i,j] = src[i,j]
+
+    @proc
+    def foo(x : R[5,5], y : R[5,5]):
+        for i in par(0,5):
+            for j in par(0,5):
+                x[i,j] = y[i,j]
+
+    foo = foo.replace(bar, "for i in _ : _")
+    print(foo)
+    assert 'bar(False, 5, y, x, 0)' in str(foo)
+
+
+


### PR DESCRIPTION
Replace should unify the subprocedure with unused control arguments.
Currently, it does not handle unused buffer arguments (what does it even
    mean when the buffer argument was tensor or window) ?