### PR TITLE
Remove token from GHA now that we are public

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,6 @@ jobs:
       - name: Checkout sources (including submodules)
         uses: actions/checkout@v2
         with:
-          token: ${{ secrets.MY_REPO_PAT }}
           submodules: recursive
 
       - name: Setup Python environment


### PR DESCRIPTION
This should fix dependabot's PR. 