### PR TITLE
Enable build workflow on PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,8 @@
 name: CI
-on: [ push, pull_request ]
+on:
+  push:
+    branches: master
+  pull_request:
 jobs:
   build:
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,5 @@
 name: CI
-on: [ push ]
+on: [ push, pull_request ]
 jobs:
   build:
     strategy:


### PR DESCRIPTION
GitHub's branch protection rules don't detect `push` statuses for whatever reason. They require `pull_request` statuses. This change will enable checks for both.