### PR TITLE
Remove dependency on cpufeature package.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ asdl==0.1.5
 astor==0.8.1
 build==0.7.0
 coverage==6.3
-cpufeature==0.2.0
 jupyter-contrib-nbextensions==0.5.1
 numpy==1.21.2
 pytest-cov==3.0.0


### PR DESCRIPTION
Replaces the `cpufeature` package with platform-specific logic to detect ISAs.

* If the `SYSTL_OVERRIDE_CPUINFO` environment variable is set to a space-separated list, uses its value.
* On Linux, parses `/proc/cpuinfo`.
* On macOS, queries x86-specific `sysctl` entries.

In all other cases, conservatively assumes that ISAs are _not_ available.